### PR TITLE
Fixing Float/Double unpacking error.

### DIFF
--- a/PHP/Sereal.php
+++ b/PHP/Sereal.php
@@ -403,12 +403,14 @@ namespace Sereal {
 		
 		protected function _d_22 ()  # TAG:FLOAT
 		{
-			return unpack('f', $this->_take(4));
+			$value = unpack('f', $this->_take(4));
+			return reset($value);
 		}
 		
 		protected function _d_23 ()  # TAG:DOUBLE
 		{
-			return unpack('d', $this->_take(8));
+			$value = unpack('d', $this->_take(8));
+			return reset($value);
 		}
 		
 		# TAG:LONG_DOUBLE - not implemented

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "dizews/php-ubjson",
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "classmap": ["PHP/"]
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "dizews/php-ubjson",
+    "name": "tobyink/php-sereal",
     "require": {
         "php": ">=5.3.0"
     },


### PR DESCRIPTION
Unpack returns an array. Floats and Doubles were incorrectly represented as an array containing a Float/Double when decoded.
